### PR TITLE
Add model info for the indian Phone (2) version

### DIFF
--- a/website/docs/devices.md
+++ b/website/docs/devices.md
@@ -14,7 +14,7 @@ Complete catalog of Nothing & CMF by Nothing products with model numbers, codena
 | Device Name | Model | Codename | Pokémon Name | Release Date |
 |-------------|-------|----------|--------------|--------------|
 | Phone (1) | A063 | Spacewar | Abra | July 2022 |
-| Phone (2) | A065 | Pong | Alakazam | July 2023 |
+| Phone (2) | A065 / AIN065 | Pong | Alakazam | July 2023 |
 | Phone (2a) | A142 | Pacman | Aerodactyl | March 2024 |
 | Phone (2a) Plus | A142P | PacmanPro | Mega Aerodactyl | August 2024 |
 | Phone (3a) / (3a) Pro | A059 / A059P | Asteroids | Arcanine | March 2025 |


### PR DESCRIPTION
There are very few references to this phone model but Nothing acknowledges it in their [*GlyphMatrix-Developer-Kit*](<https://github.com/Nothing-Developer-Programme/GlyphMatrix-Developer-Kit>) (also in their former *Glyph-Developer-Kit*) and they explicitly check that model string against the current one (second image).

com.nothing.ketchum.Glyph:
<img width="405" height="73" alt="image" src="https://github.com/user-attachments/assets/99f56acd-851d-4dc6-a4f8-53a43365e303" />
com.nothing.ketchum.Common:
<img width="746" height="113" alt="image" src="https://github.com/user-attachments/assets/9b60142e-4f53-4706-be5f-8f7febdb4f42" />

I also found these other sources mentioning it:
* https://xdaforums.com/t/nothing-phone-2-official-ota-zip-full-incremental.4604803/
* https://www.notebookcheck.net/Nothing-Phone-2-New-model-variant-appears-with-Snapdragon-8-Plus-Gen-1-12-GB-RAM-and-running-Android-13.732444.0.html
* https://www.google.com/search?q=%22AIN065%22