### PR TITLE
Added regex to match phone name

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -248,7 +248,7 @@ function groupAndSortChangelogSidebar(items: any[]): any[] {
     let brand = 'Nothing';
 
     if (matchingDevices.length > 1) {
-      const cleanNames = matchingDevices.map((d: any) => d.name.split(' (')[0]);
+      const cleanNames = matchingDevices.map((d: any) => d.name.match(/^(.*)\s\([^(]+\)$/)?.at(1) ?? "");
       cleanNames.sort();
       const joinedNames = cleanNames.join(' / ').replace(/\/ Phone \(/g, '/ (');
       


### PR DESCRIPTION
Hello,
I noticed that in `OTA Changelogs` there is link `Phone / Phone (Asteroids(Pro))` and it's missing `3a` and `3a Pro`. So I added better string parsing using Regex. So now it shows `Phone (3a) / (3a) Pro (Asteroids(Pro))`.